### PR TITLE
feat: 로그인 기능 구현

### DIFF
--- a/src/controllers/UserController.ts
+++ b/src/controllers/UserController.ts
@@ -1,6 +1,8 @@
 import conn from '../../config/mariadb';
 import { StatusCodes } from 'http-status-codes';
 import crypto from 'crypto';
+import jwt from 'jsonwebtoken';
+import { JWT_SECRET } from '../../config/config';
 
 const join = (req, res) => {
 	const { personalId, name, email, password } = req.body;
@@ -27,6 +29,35 @@ const join = (req, res) => {
 	)
 };
 
+const login = (req, res) => {
+	const { email, password } = req.body;
+
+	let sql = 'SELECT * FROM users WHERE email = ?';
+	conn.query(sql, email,
+			(err, results) => {
+					if (err) {
+							console.log(err);
+							return res.status(StatusCodes.BAD_REQUEST).end(); // BAD REQUEST
+					}
+
+					const loginUser = results[0];
+
+					// 로그인 시 받은 이메일 & 비밀번호 -> salt값 꺼내서 비밀번호 암호화
+					const hashPassword =  crypto.pbkdf2Sync(password, loginUser.salt, 10000, 10, 'sha512').toString('base64');
+
+					// 디비 비밀번호랑 비교
+					if (loginUser && loginUser.password == hashPassword) {
+
+							return res.status(StatusCodes.OK).json(results);
+					} else {
+							return res.status(StatusCodes.UNAUTHORIZED).end();
+					}
+
+			}
+	)    
+};
+
 export {
-	join
+	join,
+	login
 }

--- a/src/routes/users.ts
+++ b/src/routes/users.ts
@@ -1,10 +1,11 @@
 import { Router, json } from 'express';
-import { join } from '../controllers/UserController';
+import { join, login } from '../controllers/UserController';
 
 const router: Router = Router();
 
 router.use(json());
 
 router.post('/join', join);
+router.post('/login', login);
 
 export default router;


### PR DESCRIPTION
### 주요 기능

- body에서 전달받은 email과 password로 회원 로그인
- password를 다시 암호화하여 저장된 암호화 값과 일치하는지 확인

### 전달 사항

- 로그인에 성공하면 jwt을 발행하는 기능을 구현하는 중
- 토큰 발행에 성공하면 토근 갱신이나 로그아웃시 폐기하는 기능도 필요
- jwt 키와 데이터베이스의 비밀번호를 암호화할 수 있는 방법도 찾아야할 것이라 생각됨